### PR TITLE
Remove owner phone field

### DIFF
--- a/index.php
+++ b/index.php
@@ -640,11 +640,6 @@ session_start();
             <form id="registrationForm">
                 <div class="form-row">
                     <div class="form-group">
-                        <label for="ownerPhone">Phone Number</label>
-                        <input type="tel" id="ownerPhone" name="ownerPhone" class="form-control"
-                            placeholder="(123) 456-7890" required>
-                    </div>
-                    <div class="form-group">
                         <label for="petName">Pet's Name</label>
                         <input type="text" id="petName" name="petName" class="form-control" placeholder="Buddy"
                             required>

--- a/register_pet.php
+++ b/register_pet.php
@@ -12,7 +12,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
     $conn = getDBConnection();
 
-    $ownerPhone = $conn->real_escape_string($_POST['ownerPhone'] ?? '');
     $petName = $conn->real_escape_string($_POST['petName'] ?? '');
     $petType = $conn->real_escape_string($_POST['petType'] ?? '');
     $petBreed = $conn->real_escape_string($_POST['petBreed'] ?? '');


### PR DESCRIPTION
## Summary
- drop owner phone field from the pet registration form
- stop reading `ownerPhone` in `register_pet.php`

## Testing
- `php -l index.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68410c8d96a0833280496854c242fe68