### PR TITLE
Dynamic appointment types

### DIFF
--- a/get_appointment_types.php
+++ b/get_appointment_types.php
@@ -1,0 +1,23 @@
+<?php
+require_once 'config.php';
+header('Content-Type: application/json');
+
+$conn = getDBConnection();
+
+$sql = "SELECT type_id, type_name FROM appointment_types";
+$result = $conn->query($sql);
+
+$types = [];
+if ($result) {
+    while ($row = $result->fetch_assoc()) {
+        $types[] = [
+            'id' => $row['type_id'],
+            'name' => $row['type_name']
+        ];
+    }
+}
+
+$conn->close();
+
+echo json_encode(['success' => true, 'types' => $types]);
+?>


### PR DESCRIPTION
## Summary
- load appointment types from DB with a new API
- populate appointment type dropdown using this API

## Testing
- `php -l get_appointment_types.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684115e26ed88332a328861ac3f30d59