### PR TITLE
Load appointments from database

### DIFF
--- a/get_appointments.php
+++ b/get_appointments.php
@@ -1,0 +1,34 @@
+<?php
+require_once 'config.php';
+session_start();
+header('Content-Type: application/json');
+
+if (!isset($_SESSION['user_id'])) {
+    echo json_encode(['success' => false, 'error' => 'User not logged in']);
+    exit();
+}
+
+$conn = getDBConnection();
+$userId = (int)$_SESSION['user_id'];
+
+$sql = "SELECT a.appointment_id, a.pet_id, a.appointment_date, a.start_time, a.end_time, a.notes, a.created_at, v.full_name AS vet_name, t.type_name FROM appointments a JOIN vets v ON a.vet_id = v.vet_id JOIN appointment_types t ON a.type_id = t.type_id WHERE a.user_id = $userId ORDER BY a.appointment_date DESC, a.start_time DESC";
+$result = $conn->query($sql);
+$appointments = [];
+if ($result) {
+    while ($row = $result->fetch_assoc()) {
+        $appointments[] = [
+            'id' => $row['appointment_id'],
+            'petId' => $row['pet_id'],
+            'date' => $row['appointment_date'],
+            'time' => $row['start_time'] . ' - ' . $row['end_time'],
+            'vet' => $row['vet_name'],
+            'reason' => $row['type_name'],
+            'notes' => $row['notes'],
+            'bookingDate' => date('Y-m-d', strtotime($row['created_at']))
+        ];
+    }
+}
+
+$conn->close();
+
+echo json_encode(['success' => true, 'appointments' => $appointments]);

--- a/index.php
+++ b/index.php
@@ -290,6 +290,14 @@ session_start();
             }
         }
 
+        async function fetchAppointments() {
+            const response = await fetch('get_appointments.php');
+            const data = await response.json().catch(() => ({success:false}));
+            if (data.success) {
+                appointments = data.appointments;
+            }
+        }
+
         async function fetchSchedule() {
             const response = await fetch('get_available_times.php');
             const data = await response.json().catch(() => ({success:false}));
@@ -350,7 +358,7 @@ session_start();
             updateActiveNav('register');
         }
 
-        function showAppointments() {
+        async function showAppointments() {
             document.querySelector('.home-section').style.display = 'none';
             document.querySelector('.schedule-section').style.display = 'none';
             document.querySelector('.registration-section').style.display = 'none';
@@ -359,6 +367,7 @@ session_start();
             // Update active nav link
             updateActiveNav('appointments');
 
+            await fetchAppointments();
             // Display appointments if any exist
             displayAppointments();
         }
@@ -575,6 +584,7 @@ session_start();
         fetchPets();
         fetchSchedule();
         fetchAppointmentTypes();
+        fetchAppointments();
         showHome();
     </script>
 </body>


### PR DESCRIPTION
## Summary
- implement `get_appointments.php` endpoint to fetch appointments
- load appointments on page load and when viewing appointments

## Testing
- `php --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68411797f0f483328c1bd03cd52b8da3