### PR TITLE
Implement appointment cancellation

### DIFF
--- a/cancel_appointment.php
+++ b/cancel_appointment.php
@@ -1,0 +1,36 @@
+<?php
+require_once 'config.php';
+session_start();
+header('Content-Type: application/json');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    echo json_encode(['success' => false, 'error' => 'Invalid request']);
+    exit();
+}
+
+if (!isset($_SESSION['user_id'])) {
+    echo json_encode(['success' => false, 'error' => 'User not logged in']);
+    exit();
+}
+
+$appointmentId = (int)($_POST['appointment_id'] ?? 0);
+if (!$appointmentId) {
+    echo json_encode(['success' => false, 'error' => 'Missing appointment id']);
+    exit();
+}
+
+$conn = getDBConnection();
+$userId = (int)$_SESSION['user_id'];
+
+$stmt = $conn->prepare("UPDATE appointments SET status='cancelled' WHERE appointment_id=? AND user_id=?");
+$stmt->bind_param('ii', $appointmentId, $userId);
+$stmt->execute();
+
+if ($stmt->affected_rows > 0) {
+    echo json_encode(['success' => true]);
+} else {
+    echo json_encode(['success' => false, 'error' => 'Appointment not found']);
+}
+
+$stmt->close();
+$conn->close();

--- a/get_appointments.php
+++ b/get_appointments.php
@@ -11,7 +11,7 @@ if (!isset($_SESSION['user_id'])) {
 $conn = getDBConnection();
 $userId = (int)$_SESSION['user_id'];
 
-$sql = "SELECT a.appointment_id, a.pet_id, a.appointment_date, a.start_time, a.end_time, a.notes, a.created_at, v.full_name AS vet_name, t.type_name FROM appointments a JOIN vets v ON a.vet_id = v.vet_id JOIN appointment_types t ON a.type_id = t.type_id WHERE a.user_id = $userId ORDER BY a.appointment_date DESC, a.start_time DESC";
+$sql = "SELECT a.appointment_id, a.pet_id, a.appointment_date, a.start_time, a.end_time, a.notes, a.created_at, v.full_name AS vet_name, t.type_name FROM appointments a JOIN vets v ON a.vet_id = v.vet_id JOIN appointment_types t ON a.type_id = t.type_id WHERE a.user_id = $userId AND a.status='scheduled' ORDER BY a.appointment_date DESC, a.start_time DESC";
 $result = $conn->query($sql);
 $appointments = [];
 if ($result) {

--- a/index.php
+++ b/index.php
@@ -489,11 +489,23 @@ session_start();
             appointmentsList.innerHTML = html;
         }
 
-        function cancelAppointment(appointmentId) {
+        async function cancelAppointment(appointmentId) {
             if (confirm('Are you sure you want to cancel this appointment?')) {
-                appointments = appointments.filter(app => app.id !== appointmentId);
-                displayAppointments();
-                alert('Appointment cancelled successfully.');
+                const formData = new FormData();
+                formData.append("appointment_id", appointmentId);
+
+                const response = await fetch("cancel_appointment.php", {
+                    method: "POST",
+                    body: formData
+                });
+                const data = await response.json().catch(() => ({success:false}));
+                if (data.success) {
+                    appointments = appointments.filter(app => app.id !== appointmentId);
+                    displayAppointments();
+                    alert("Appointment cancelled successfully.");
+                } else {
+                    alert("Error cancelling appointment.");
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- add server-side cancellation handler
- load only scheduled appointments in API
- hook up cancel button to new endpoint

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68411ac2d50483329e01ef1b195d0319