### PR TITLE
Add doctor login link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,6 @@ This update introduces a simple login and dashboard for veterinarians.  Doctors
 can sign in through `doctor_login.php` and view their pending appointments and
 appointment history on `doctor_dashboard.php`.  The database schema now includes
 a `password_hash` column in the `vets` table for authentication.
+
+The regular `login.php` page also provides a link to the doctor login for easy
+access.

--- a/login.php
+++ b/login.php
@@ -51,6 +51,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         </form>
         <br>
         <p>Don't have an account? <a href="register.php">Register here</a></p>
+        <p>Are you a veterinarian? <a href="doctor_login.php">Doctor Login</a></p>
     </div>
 </body>
 


### PR DESCRIPTION
## Summary
- link from standard login page to doctor login
- document doctor link in README

## Testing
- `php -l login.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68539bcd173083328a6737bc64e16ea5