### PR TITLE
Add admin login and dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,9 @@ a `password_hash` column in the `vets` table for authentication.
 
 The regular `login.php` page also provides a link to the doctor login for easy
 access.
+
+## Admin Accounts
+
+Administrators can sign in through `admin_login.php`. Upon successful login they
+are taken to `admin_dashboard.php`, which lists all registered veterinarians.
+Admin credentials are stored in a new `admins` table created in `pet_pro.sql`.

--- a/admin_dashboard.php
+++ b/admin_dashboard.php
@@ -1,0 +1,49 @@
+<?php
+session_start();
+require_once 'config.php';
+
+if (!isset($_SESSION['admin_id'])) {
+    header('Location: admin_login.php');
+    exit();
+}
+
+$conn = getDBConnection();
+$vets = [];
+$result = $conn->query("SELECT vet_id, full_name, email FROM vets ORDER BY full_name");
+if ($result) {
+    $vets = $result->fetch_all(MYSQLI_ASSOC);
+}
+$conn->close();
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Admin Dashboard</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+<?php include 'header_admin.php'; ?>
+<div class="container">
+    <h2>Welcome, <?php echo htmlspecialchars($_SESSION['admin_name']); ?></h2>
+    <h3>Registered Veterinarians</h3>
+    <table class="schedule-table">
+        <thead>
+            <tr>
+                <th>Name</th>
+                <th>Email</th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php foreach ($vets as $row): ?>
+            <tr>
+                <td><?php echo htmlspecialchars($row['full_name']); ?></td>
+                <td><?php echo htmlspecialchars($row['email']); ?></td>
+            </tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
+</div>
+</body>
+</html>

--- a/admin_login.php
+++ b/admin_login.php
@@ -7,13 +7,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $conn = getDBConnection();
     $email = $conn->real_escape_string($_POST['email'] ?? '');
     $password = $_POST['password'] ?? '';
-    $result = $conn->query("SELECT user_id, full_name, password_hash FROM users WHERE email = '$email'");
+    $result = $conn->query("SELECT admin_id, full_name, password_hash FROM admins WHERE email = '$email'");
     if ($result && $result->num_rows === 1) {
-        $user = $result->fetch_assoc();
-        if (password_verify($password, $user['password_hash'])) {
-            $_SESSION['user_id'] = $user['user_id'];
-            $_SESSION['full_name'] = $user['full_name'];
-            header('Location: index.php');
+        $admin = $result->fetch_assoc();
+        if (password_verify($password, $admin['password_hash'])) {
+            $_SESSION['admin_id'] = $admin['admin_id'];
+            $_SESSION['admin_name'] = $admin['full_name'];
+            header('Location: admin_dashboard.php');
             exit();
         }
     }
@@ -22,18 +22,16 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 ?>
 <!DOCTYPE html>
 <html lang="en">
-
 <head>
     <meta charset="UTF-8">
-    <title>Login</title>
+    <title>Admin Login</title>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link rel="stylesheet" href="styles.css">
 </head>
-
 <body>
-    <?php include 'header.php'; ?>
+    <?php include 'header_admin.php'; ?>
     <div class="container">
-        <h2>Login</h2>
+        <h2>Admin Login</h2>
         <br>
         <?php if ($error): ?>
             <p class="error"><?php echo $error; ?></p>
@@ -50,10 +48,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             <button type="submit" class="btn">Login</button>
         </form>
         <br>
-        <p>Don't have an account? <a href="register.php">Register here</a></p>
-        <p>Are you a veterinarian? <a href="doctor_login.php">Doctor Login</a></p>
-        <p>Admin user? <a href="admin_login.php">Admin Login</a></p>
+        <p>Back to the main <a href="login.php">User Login</a></p>
     </div>
 </body>
-
 </html>

--- a/admin_logout.php
+++ b/admin_logout.php
@@ -1,0 +1,7 @@
+<?php
+session_start();
+session_unset();
+session_destroy();
+header('Location: admin_login.php');
+exit();
+?>

--- a/header_admin.php
+++ b/header_admin.php
@@ -1,0 +1,23 @@
+<?php
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+?>
+<header>
+    <div class="nav-container">
+        <div class="logo">
+            <i class="fas fa-paw"></i>
+            <span>PetCare Pro</span>
+        </div>
+        <nav>
+            <ul>
+                <?php if (isset($_SESSION['admin_id'])): ?>
+                    <li><a href="admin_dashboard.php">Dashboard</a></li>
+                    <li><a href="admin_logout.php">Logout</a></li>
+                <?php else: ?>
+                    <li><a href="admin_login.php">Login</a></li>
+                <?php endif; ?>
+            </ul>
+        </nav>
+    </div>
+</header>

--- a/pet_pro.sql
+++ b/pet_pro.sql
@@ -33,3 +33,13 @@ INSERT INTO `appointment_types` (`type_name`, `pet_type`, `description`, `durati
 ('Check-up', 'small mammal', 'General exam for small mammals', 20),
 ('Nutrition Advice', 'small mammal', 'Diet consultation', 15),
 ('General Examination', 'other', 'General health exam', 30);
+
+-- Table structure for table `admins`
+CREATE TABLE `admins` (
+  `admin_id` int(11) NOT NULL AUTO_INCREMENT,
+  `full_name` varchar(100) NOT NULL,
+  `email` varchar(100) NOT NULL,
+  `password_hash` varchar(255) NOT NULL,
+  PRIMARY KEY (`admin_id`),
+  UNIQUE KEY `email` (`email`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;


### PR DESCRIPTION
## Summary
- add admin header, login, dashboard and logout
- allow admins to login from the main login page
- document admin accounts
- provide admins table in pet_pro.sql

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685539666e0c833281609ac62f78f13b