### PR TITLE
Fix ordering of admins table indexes

### DIFF
--- a/pet_pro.sql
+++ b/pet_pro.sql
@@ -172,11 +172,6 @@ ALTER TABLE `users`
   ADD PRIMARY KEY (`user_id`),
   ADD UNIQUE KEY `email` (`email`);
 
--- Indexes for table `admins`
-ALTER TABLE `admins`
-  ADD PRIMARY KEY (`admin_id`),
-  ADD UNIQUE KEY `email` (`email`);
-
 --
 -- Indexes for table `vets`
 --
@@ -232,6 +227,11 @@ CREATE TABLE `admins` (
   `email` varchar(100) NOT NULL,
   `password_hash` varchar(255) NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+-- Indexes for table `admins`
+ALTER TABLE `admins`
+  ADD PRIMARY KEY (`admin_id`),
+  ADD UNIQUE KEY `email` (`email`);
+
 
 --
 -- AUTO_INCREMENT for table `pets`


### PR DESCRIPTION
## Summary
- fix SQL dump sequence so `admins` table is created before indexing

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855438593d88332bbeab3452f81b49c