### PR TITLE
Add appointment completion/cancel controls

### DIFF
--- a/doctor_dashboard.php
+++ b/doctor_dashboard.php
@@ -54,6 +54,7 @@ $conn->close();
                 <th>Time</th>
                 <th>Reason</th>
                 <th>Status</th>
+                <th>Actions</th>
             </tr>
         </thead>
         <tbody>
@@ -65,6 +66,18 @@ $conn->close();
                 <td><?php echo htmlspecialchars($row['start_time'] . ' - ' . $row['end_time']); ?></td>
                 <td><?php echo htmlspecialchars($row['type_name']); ?></td>
                 <td><?php echo htmlspecialchars($row['status']); ?></td>
+                <td>
+                    <form method="POST" action="update_appointment_status.php" style="display:inline;">
+                        <input type="hidden" name="appointment_id" value="<?php echo $row['appointment_id']; ?>">
+                        <input type="hidden" name="status" value="completed">
+                        <button type="submit" class="btn" style="padding:0.3rem 0.6rem;">Complete</button>
+                    </form>
+                    <form method="POST" action="update_appointment_status.php" style="display:inline;">
+                        <input type="hidden" name="appointment_id" value="<?php echo $row['appointment_id']; ?>">
+                        <input type="hidden" name="status" value="cancelled">
+                        <button type="submit" class="btn" style="background-color: var(--danger-color); padding:0.3rem 0.6rem;">Cancel</button>
+                    </form>
+                </td>
             </tr>
         <?php endforeach; ?>
         </tbody>

--- a/update_appointment_status.php
+++ b/update_appointment_status.php
@@ -1,0 +1,35 @@
+<?php
+require_once 'config.php';
+session_start();
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    header('Location: doctor_dashboard.php');
+    exit();
+}
+
+if (!isset($_SESSION['vet_id'])) {
+    header('Location: doctor_login.php');
+    exit();
+}
+
+$appointmentId = (int)($_POST['appointment_id'] ?? 0);
+$status = $_POST['status'] ?? '';
+
+if (!$appointmentId || !in_array($status, ['completed', 'cancelled'])) {
+    header('Location: doctor_dashboard.php');
+    exit();
+}
+
+$conn = getDBConnection();
+$vetId = (int)$_SESSION['vet_id'];
+
+$stmt = $conn->prepare("UPDATE appointments SET status=? WHERE appointment_id=? AND vet_id=?");
+$stmt->bind_param('sii', $status, $appointmentId, $vetId);
+$stmt->execute();
+$stmt->close();
+
+$conn->close();
+
+header('Location: doctor_dashboard.php');
+exit();
+?>


### PR DESCRIPTION
## Summary
- allow vets to mark appointments as completed or cancelled
- expose `update_appointment_status.php` to update an appointment's status
- update doctor dashboard UI to include action buttons

## Testing
- `php -l update_appointment_status.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68589ba237908332a6ec6edcc5ff8573